### PR TITLE
Add cmd+k hotkeys for menu items in cmd+k menu

### DIFF
--- a/src/components/cmd-k/command-menu.tsx
+++ b/src/components/cmd-k/command-menu.tsx
@@ -10,21 +10,25 @@ const shortcuts = [
     title: "Home",
     onSelect: () => "/",
     keywords: "home main landing",
+    hotkey: "h"
   },
   {
     title: "Essays",
     onSelect: () => "/essays",
     keywords: "writing blog posts articles",
+    hotkey: "e"
   },
   {
     title: "Projects",
     onSelect: () => "/projects",
     keywords: "work portfolio code",
+    hotkey: "p"
   },
   {
     title: "Contact",
     onSelect: () => "/contact",
     keywords: "email message reach",
+    hotkey: "c"
   },
 ]
 
@@ -39,11 +43,19 @@ export function CommandMenu() {
         e.preventDefault()
         setOpen((open) => !open)
       }
+
+      shortcuts.forEach(shortcut => {
+        if (e.key === shortcut.hotkey && (e.metaKey || e.ctrlKey)) {
+          e.preventDefault()
+          router.push(shortcut.onSelect())
+          setOpen(false)
+        }
+      })
     }
 
     document.addEventListener('keydown', down)
     return () => document.removeEventListener('keydown', down)
-  }, [])
+  }, [router])
 
   return (
     <Dialog.Root open={open} onOpenChange={setOpen}>


### PR DESCRIPTION
Fixes #27

Add hotkeys for cmd+k menu items.

* Add `hotkey` property to each item in the `shortcuts` array.
* Update `Command.Item` to listen for the respective hotkey and trigger the corresponding action.
* Update `useEffect` hook to include event listeners for the new hotkeys.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ks93/sundli.ai/pull/28?shareId=72708d94-d04c-4a79-a7b9-3da796f07bcf).