### PR TITLE
Fix static footer year

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,8 +8,7 @@ const styles = {
   commandHint: "text-muted-foreground",
   kbd: "px-2 py-1 text-sm rounded bg-secondary text-secondary-foreground",
   linkContainer: "flex gap-4",
-  link: "text-sm px-4 py-2 rounded-md bg-secondary text-secondary-foreground hover:bg-secondary/80 transition-colors",
-  footer: "mt-12 text-sm text-muted-foreground"
+  link: "text-sm px-4 py-2 rounded-md bg-secondary text-secondary-foreground hover:bg-secondary/80 transition-colors"
 }
 
 export default function Home() {
@@ -34,7 +33,7 @@ export default function Home() {
         </div>
       </div>
 
-      <Footer className={styles.footer} />
+      <Footer />
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { Footer } from '@/components/layout/footer';
 
 const styles = {
   container: "h-full flex flex-col items-center justify-center space-y-8",
@@ -12,7 +13,6 @@ const styles = {
 }
 
 export default function Home() {
-  const currentYear = new Date().getFullYear();
 
   return (
     <main className={styles.container}>
@@ -34,9 +34,7 @@ export default function Home() {
         </div>
       </div>
 
-      <div className={styles.footer}>
-        <p>© {currentYear} Kelvin Sundli</p>
-      </div>
+      <Footer className={styles.footer} />
     </main>
   );
 }

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+interface FooterProps {
+  className?: string;
+}
+
+export function Footer({ className }: FooterProps) {
+  const currentYear = new Date().getFullYear();
+  return (
+    <footer className={cn('mt-12 text-sm text-muted-foreground', className)}>
+      <p>© {currentYear} Kelvin Sundli</p>
+    </footer>
+  );
+}

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import { cn } from '@/lib/utils';
 
 interface FooterProps {
@@ -7,10 +8,15 @@ interface FooterProps {
 }
 
 export function Footer({ className }: FooterProps) {
-  const currentYear = new Date().getFullYear();
+  const [currentYear, setCurrentYear] = useState<number | null>(null);
+
+  useEffect(() => {
+    setCurrentYear(new Date().getFullYear());
+  }, []);
+
   return (
     <footer className={cn('mt-12 text-sm text-muted-foreground', className)}>
-      <p>© {currentYear} Kelvin Sundli</p>
+      <p>© {currentYear ?? ''} Kelvin Sundli</p>
     </footer>
   );
 }


### PR DESCRIPTION
## Summary
- add a client-side `Footer` component that calculates the year at runtime
- use the new `Footer` on the home page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688401f842688327876d7ba4fb21e699