### PR TITLE
Add simple 404 page

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+import { PageContainer } from '@/components/layout/page-container';
+
+export default function NotFound() {
+  return (
+    <PageContainer
+      title="404"
+      description="Sorry, we couldn't find the page you're looking for."
+    >
+      <Link
+        href="/"
+        className="inline-block mt-4 text-sm px-4 py-2 rounded-md bg-secondary text-secondary-foreground hover:bg-secondary/80 transition-colors"
+      >
+        Go back home
+      </Link>
+    </PageContainer>
+  );
+}


### PR DESCRIPTION
## Summary
- add a site-wide `not-found.tsx` page that shows a helpful message and link home

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688403179ab883279158a4cb417a4b83