### PR TITLE
Revamp site styling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -36,33 +36,33 @@
   }
 
   .dark {
-    --background: 0 0% 0%;
-    --foreground: 0 0% 98%;
+    --background: 240 6% 10%;
+    --foreground: 0 0% 100%;
 
-    --card: 0 0% 3.9%;
-    --card-foreground: 0 0% 98%;
+    --card: 240 6% 15%;
+    --card-foreground: 0 0% 100%;
 
-    --popover: 0 0% 3.9%;
-    --popover-foreground: 0 0% 98%;
+    --popover: 240 6% 15%;
+    --popover-foreground: 0 0% 100%;
 
-    --primary: 0 0% 98%;
-    --primary-foreground: 0 0% 9%;
+    --primary: 265 80% 60%;
+    --primary-foreground: 0 0% 100%;
 
-    --secondary: 0 0% 14.9%;
+    --secondary: 240 4% 20%;
     --secondary-foreground: 0 0% 98%;
 
-    --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
+    --muted: 240 4% 25%;
+    --muted-foreground: 240 5% 65%;
 
-    --accent: 0 0% 14.9%;
-    --accent-foreground: 0 0% 98%;
+    --accent: 265 80% 65%;
+    --accent-foreground: 0 0% 100%;
 
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
 
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
-    --ring: 0 0% 83.1%;
+    --border: 240 4% 20%;
+    --input: 240 4% 20%;
+    --ring: 240 5% 65%;
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { GeistSans } from 'geist/font/sans'
+import { Space_Grotesk } from 'next/font/google'
 import { CommandMenu } from '@/components/cmd-k/command-menu'
 import './globals.css'
 
@@ -16,17 +17,28 @@ export const metadata: Metadata = {
   },
 }
 
+const grotesk = Space_Grotesk({
+  subsets: ['latin'],
+  weight: '700',
+  display: 'swap',
+})
+
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en" className="dark h-full">
+    <html
+      lang="en"
+      className={`dark h-full scroll-smooth ${grotesk.className}`}
+    >
       <body
-        className={`${GeistSans.className} bg-black text-white antialiased h-full`}
+        className={`${GeistSans.className} bg-[radial-gradient(ellipse_at_top_left,_var(--tw-gradient-stops))] from-[#151515] via-[#0b0717] to-black text-white antialiased min-h-screen`}
       >
-        <main className="mx-auto max-w-4xl px-4 py-8 h-full">{children}</main>
+        <main className="mx-auto max-w-4xl px-4 py-8 min-h-screen flex flex-col">
+          {children}
+        </main>
         <CommandMenu />
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,20 +1,28 @@
 import Link from 'next/link'
 import { Footer } from '@/components/layout/footer'
+import { Space_Grotesk } from 'next/font/google'
+
+const titleFont = Space_Grotesk({
+  subsets: ['latin'],
+  weight: '700',
+  display: 'swap',
+})
 
 const styles = {
-  container: 'h-full flex flex-col items-center justify-center space-y-8',
-  title: 'text-4xl font-bold tracking-tight',
-  contentWrapper: 'flex flex-col items-center space-y-4',
+  container: 'min-h-screen flex flex-col items-center justify-center gap-8',
+  title:
+    'text-6xl font-extrabold tracking-tight bg-gradient-to-r from-fuchsia-500 via-cyan-500 to-fuchsia-500 text-transparent bg-clip-text bg-[length:200%_200%] animate-gradient-move',
+  contentWrapper: 'flex flex-col items-center gap-4',
   commandHint: 'text-muted-foreground',
   kbd: 'px-2 py-1 text-sm rounded bg-secondary text-secondary-foreground',
   linkContainer: 'flex gap-4',
-  link: 'text-sm px-4 py-2 rounded-md bg-secondary text-secondary-foreground hover:bg-secondary/80 transition-colors',
+  link: 'text-sm px-4 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/80 transition-colors border border-primary/50 hover:border-primary',
 }
 
 export default function Home() {
   return (
     <main className={styles.container}>
-      <h1 className={styles.title}>sundli.ai</h1>
+      <h1 className={`${styles.title} ${titleFont.className}`}>sundli.ai</h1>
 
       <div className={styles.contentWrapper}>
         <p className={styles.commandHint}>

--- a/src/components/cmd-k/command-menu.tsx
+++ b/src/components/cmd-k/command-menu.tsx
@@ -33,15 +33,16 @@ const shortcuts = [
 ]
 
 const styles = {
-  overlay: 'fixed inset-0 bg-black/50 animate-fade-in',
+  overlay:
+    'fixed inset-0 bg-gradient-to-br from-black/80 via-black/60 to-black/80 backdrop-blur-sm animate-fade-in',
   content:
-    'fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 max-w-[640px] w-[90vw] bg-background border border-border rounded-lg shadow-lg p-2 animate-fade-in',
+    'fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 max-w-[640px] w-[90vw] bg-background/80 backdrop-blur-md border border-border/60 rounded-xl shadow-xl p-2 animate-fade-in',
   input:
     'w-full bg-transparent border-none outline-none p-4 text-foreground placeholder:text-muted-foreground',
   empty: 'p-4 text-sm text-muted-foreground',
-  item: 'p-4 rounded-md text-sm text-foreground hover:bg-secondary cursor-pointer flex items-center justify-between data-[selected=true]:bg-secondary',
+  item: 'p-4 rounded-md text-sm text-foreground hover:bg-secondary/80 cursor-pointer flex items-center justify-between data-[selected=true]:bg-secondary transition-colors',
   hotkey:
-    'ml-auto text-xs text-muted-foreground bg-secondary px-2 py-1 rounded',
+    'ml-auto text-xs text-primary bg-primary/20 px-2 py-1 rounded transition-colors',
 }
 
 export function CommandMenu() {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -74,12 +74,17 @@ const config: Config = {
           from: { height: 'var(--radix-accordion-content-height)' },
           to: { height: '0' },
         },
+        'gradient-move': {
+          '0%, 100%': { 'background-position': '0% 50%' },
+          '50%': { 'background-position': '100% 50%' },
+        },
       },
       animation: {
         'fade-in': 'fade-in 0.2s ease-in-out',
         'fade-out': 'fade-out 0.2s ease-in-out',
         'accordion-down': 'accordion-down 0.2s ease-out',
         'accordion-up': 'accordion-up 0.2s ease-out',
+        'gradient-move': 'gradient-move 8s ease infinite',
       },
     },
   },


### PR DESCRIPTION
## Summary
- apply radial gradient background and scroll-smooth
- animate heading gradient and add gradient border to links
- tune dark color palette and overlay blur
- add gradient animation utilities in Tailwind

## Testing
- `npm run format`
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6884149675b48327a208fed1499e0a41